### PR TITLE
Standardize basic mission report

### DIFF
--- a/common/src/types/mission_report.rs
+++ b/common/src/types/mission_report.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+/// Summary statistics for a completed mission.
+///
+/// On real hardware, fields are populated from ESKF estimates and IMU data.
+/// In simulation, they may be populated from simulator ground truth instead.
+/// Field-level comments note when the source differs.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct MissionReport {
+    /// Whether the mission completed without a ground collision
+    pub mission_completed: bool,
+    /// Maximum altitude above the starting position [m]
+    pub max_altitude_m: f32,
+    /// Average ground speed over the full mission [m/s]
+    pub avg_speed_ms: f32,
+    /// Maximum ground speed [m/s]
+    pub max_speed_ms: f32,
+    /// Maximum specific force (gravity-subtracted) while airborne [m/s^2]
+    pub max_acceleration_ms2: f32,
+    /// Whether the vehicle descended below the starting plane
+    pub ground_collision: bool,
+    /// Speed at last ground contact during landing [m/s]
+    pub landing_speed_ms: f32,
+    /// Final position in NED frame [m]
+    pub final_position_m: [f32; 3],
+}

--- a/common/src/types/mod.rs
+++ b/common/src/types/mod.rs
@@ -7,4 +7,5 @@ pub mod flight_mode;
 // pub mod error;
 pub mod gcs_comm;
 pub mod measurements;
+pub mod mission_report;
 pub mod status;

--- a/device/std-test-device/Cargo.toml
+++ b/device/std-test-device/Cargo.toml
@@ -26,6 +26,7 @@ embedded-storage-async = "0.4.1"
 rand = "0.9.2"
 rand_distr = "0.5.1"
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1"
 clap = { version = "4.5.49", features = ["derive"] }
 tokio = { version = "1.48.0", features = ["io-std", "io-util", "macros", "net", "rt", "rt-multi-thread"] }
 

--- a/device/std-test-device/src/lib.rs
+++ b/device/std-test-device/src/lib.rs
@@ -2,7 +2,7 @@ use std::{
     f32::consts::PI,
     sync::{
         atomic::{AtomicBool, Ordering},
-        LazyLock,
+        Arc, LazyLock, Mutex,
     },
 };
 
@@ -29,6 +29,7 @@ pub static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
 static RUNNING: AtomicBool = AtomicBool::new(true);
 
 #[derive(clap::Parser)]
+#[clap(ignore_errors = true)]
 pub struct Args {
     /// Path to the configuration file for the simulation
     #[clap(default_value = "sim_config.toml")]
@@ -38,12 +39,41 @@ pub struct Args {
 
 const SIM_FREQUENCY: u64 = 500;
 
+
+pub use common::types::mission_report::MissionReport;
+
+/// Wraps `MissionReport` with simulation-specific metadata that has no
+/// equivalent on real hardware.
+#[derive(Clone, serde::Serialize)]
+pub struct SimMissionReport {
+    pub test_name: String,
+    pub sim_time_s: u64,
+    pub wall_time_s: f64,
+    pub speed_factor: f64,
+    pub total_steps: u64,
+    #[serde(flatten)]
+    pub report: MissionReport,
+}
+
+impl SimMissionReport {
+    fn print_json(&self) {
+        println!("{}", serde_json::to_string_pretty(self).unwrap());
+    }
+
+    pub fn save_to_file(&self, path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json)?;
+        Ok(())
+    }
+}
+
 pub fn test_entry(
     limit_seconds: u64,
-    #[allow(unused)]
     test_name: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<SimMissionReport, Box<dyn std::error::Error>> {
     let _enter = RUNTIME.enter();
+
+    RUNNING.store(true, Ordering::Relaxed);
 
     let args = Args::parse();
     let config = holsatus_sim::config::load_from_file_path(&args.config)?;
@@ -53,9 +83,32 @@ pub fn test_entry(
     #[cfg(feature = "rerun")]
     let mut logger = rerun_logger::setup(sitl.clone(), 10, test_name)?;
 
+    // When rerun is not active, fall back to env_logger (respects RUST_LOG, defaults to warn)
+    #[cfg(not(feature = "rerun"))]
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Warn)
+        .try_init();
+
     // Sometimes rerun can take a split second to start receiving
     #[cfg(feature = "rerun")]
     std::thread::sleep(std::time::Duration::from_millis(100));
+
+    let wall_start = std::time::Instant::now();
+    let test_name = test_name.to_string();
+
+    let mut max_altitude_m = 0.0f32;
+    let mut speed_sum_ms = 0.0f32;
+    let mut max_speed_ms = 0.0f32;
+    let mut max_accel_ms2 = 0.0f32;
+    let mut ground_collision = false;
+    let mut landing_speed_ms = 0.0f32;
+    let mut total_steps = 0u64;
+    #[allow(unused_assignments)]
+    let mut final_pos = [0.0f32; 3];
+
+    // Shared slot so the closure can hand the report back out after lockstep ends.
+    let report_slot: Arc<Mutex<Option<SimMissionReport>>> = Arc::new(Mutex::new(None));
+    let report_write = report_slot.clone();
 
     let fw_sitl = sitl.clone();
     lockstep::lockstep_with(
@@ -64,11 +117,74 @@ pub fn test_entry(
             #[cfg(feature = "rerun")]
             logger.log_subsampled().unwrap();
 
-            assert!(Instant::now().as_secs() < limit_seconds);
+            // Graceful time-limit check (replaces assert)
+            if Instant::now().as_secs() >= limit_seconds {
+                log::warn!("Simulation time limit of {limit_seconds}s reached");
+                RUNNING.store(false, Ordering::Relaxed);
+            }
+
+            let state = sitl.vehicle_state();
+            let pos = state.position;
+
+            // NED: negative z = above ground, ground is at z >= 0
+            let altitude_m = -pos.z;
+            let speed_ms = state.velocity.norm();
+
+            // Specific force (gravity-subtracted), matching what body_acc_norm shows
+            // in the rerun plot. Only tracked while airborne to exclude ground-contact
+            // impulses from the physics solver at touchdown.
+            if altitude_m > 0.3 {
+                max_accel_ms2 = max_accel_ms2.max(state.body_acc.norm());
+            }
+
+            max_altitude_m = max_altitude_m.max(altitude_m);
+            speed_sum_ms += speed_ms;
+            max_speed_ms = max_speed_ms.max(speed_ms);
+
+            // Ground collision: drone went below starting plane
+            if pos.z > 0.1 {
+                ground_collision = true;
+            }
+
+            // Landing speed: last speed recorded while near ground
+            if altitude_m < 0.5 {
+                landing_speed_ms = speed_ms;
+            }
+
+
+            total_steps += 1;
+            final_pos = [pos.x, pos.y, pos.z];
 
             let step_size = embassy_time::Duration::from_hz(SIM_FREQUENCY);
             sitl.step(step_size.as_micros() as f32 * 1e-6);
-            RUNNING.load(Ordering::Relaxed).then_some(step_size)
+
+            let still_running = RUNNING.load(Ordering::Relaxed);
+
+            if !still_running {
+                let sim_secs = Instant::now().as_secs();
+                let wall_secs = wall_start.elapsed().as_secs_f64();
+                let sim_report = SimMissionReport {
+                    test_name: test_name.clone(),
+                    sim_time_s: sim_secs,
+                    wall_time_s: wall_secs,
+                    speed_factor: sim_secs as f64 / wall_secs,
+                    total_steps,
+                    report: MissionReport {
+                        mission_completed: !ground_collision,
+                        max_altitude_m,
+                        avg_speed_ms: speed_sum_ms / total_steps as f32,
+                        max_speed_ms,
+                        max_acceleration_ms2: max_accel_ms2,
+                        ground_collision,
+                        landing_speed_ms,
+                        final_position_m: final_pos,
+                    },
+                };
+                sim_report.print_json();
+                *report_write.lock().unwrap() = Some(sim_report);
+            }
+
+            still_running.then_some(step_size)
         },
     );
 
@@ -76,7 +192,10 @@ pub fn test_entry(
     #[cfg(feature = "rerun")]
     std::thread::sleep(std::time::Duration::from_millis(100));
 
-    Ok(())
+    Arc::try_unwrap(report_slot)
+        .map_err(|_| "report Arc still shared after lockstep")?
+        .into_inner()?
+        .ok_or_else(|| "simulation ended without producing a report".into())
 }
 
 fn firmware_entry(spawner: Spawner, r: Resources, sim: SimHandle) {

--- a/device/std-test-device/src/rerun_logger.rs
+++ b/device/std-test-device/src/rerun_logger.rs
@@ -66,6 +66,7 @@ impl RerunLogger {
         let state = self.handle.vehicle_state();
         let pos = state.position;
         let rot = state.rotation;
+        let body_acc = state.body_acc;
 
         if self.pos_trail.len() >= self.trail_len {
             _ = self.pos_trail.pop_back();
@@ -236,6 +237,17 @@ impl RerunLogger {
 
         self.rec
             .log("sim/position", &Scalars::new(pos.data.0[0]))
+            .unwrap();
+
+        self.rec
+            .log("sim/body_acc", &Scalars::new(body_acc.data.0[0]))
+            .unwrap();
+
+        self.rec
+            .log(
+                "sim/body_acc_norm",
+                &Scalars::single(body_acc.norm() as f64),
+            )
             .unwrap();
 
         let (roll, pitch, yaw) = rot.euler_angles();

--- a/device/std-test-device/tests/integration_test.rs
+++ b/device/std-test-device/tests/integration_test.rs
@@ -2,5 +2,27 @@
 
 #[test]
 fn flight_pattern() {
-    std_device::test_entry(60, "integration-test-flight-pattern").unwrap()
+    let report = std_device::test_entry(60, "integration-test-flight-pattern").unwrap();
+
+    assert!(report.report.mission_completed, "mission did not complete");
+    assert!(!report.report.ground_collision, "ground collision detected");
+    assert!(
+        report.report.max_altitude_m > 9.0,
+        "never reached 10m target altitude"
+    );
+    assert!(
+        report.report.landing_speed_ms < 1.0,
+        "landing speed too high: {:.2} m/s",
+        report.report.landing_speed_ms
+    );
+    assert!(
+        report.report.max_acceleration_ms2 < 20.0,
+        "max acceleration to high: {:.2} m/s/s",
+        report.report.max_acceleration_ms2
+    );
+    assert!(
+        report.speed_factor > 100.0,
+        "simulation slower than expected: {:.2} t_sim/t_wall",
+        report.speed_factor,
+    );
 }

--- a/device/std-test-device/tests/integration_test.rs
+++ b/device/std-test-device/tests/integration_test.rs
@@ -20,9 +20,4 @@ fn flight_pattern() {
         "max acceleration to high: {:.2} m/s/s",
         report.report.max_acceleration_ms2
     );
-    assert!(
-        report.speed_factor > 100.0,
-        "simulation slower than expected: {:.2} t_sim/t_wall",
-        report.speed_factor,
-    );
 }


### PR DESCRIPTION
Separate report fields that can be implemented for any device and sim-specific fields.

Preview like so:

`cd device/std-test-device/ && cargo test --release -- --nocapture
`