### PR TITLE
fix: compile error on mavlink build_frame()

### DIFF
--- a/common/src/mavlink/mod.rs
+++ b/common/src/mavlink/mod.rs
@@ -722,11 +722,7 @@ fn build_frame<V: Versioned>(
         .component_id(param.id.com)
         .sequence(sequence)
         .version(V::v())
-        .message(message)
-        .map_err(|e| match e {
-            mavio::Error::Spec(spec_error) => spec_error,
-            _ => unreachable!("This always produces a spec_error"),
-        })?
+        .message(message)?
         .build();
 
     Ok(message)


### PR DESCRIPTION
Seems like code does not compile since around 2026-03-15 and there was a lot of changes, so I just offering what worked for me. Please check if it's a good way to fix it.

I got:
error[E0308]: mismatched types
holsatus-flight/common/src/mavlink/mod.rs:727
expected `SpecError`, found `Error`